### PR TITLE
fix: Responsive example not working in safari mobile

### DIFF
--- a/example-apps/responsive-dashboard/src/screens/dashboard.tsx
+++ b/example-apps/responsive-dashboard/src/screens/dashboard.tsx
@@ -50,6 +50,7 @@ export function Dashboard({
       /* @ts-ignore */
       direction={{ base: "column", md: "column", sm: "column", lg: "row" }}
       h="100%"
+      flex={1}
     >
       <LeftPanel navigation={navigation} />
       <ScrollView>

--- a/example-apps/responsive-dashboard/src/screens/setting.tsx
+++ b/example-apps/responsive-dashboard/src/screens/setting.tsx
@@ -40,6 +40,7 @@ export function Setting({
         /* @ts-ignore */
         direction={{ base: "column", md: "column", sm: "column", lg: "row" }}
         h="100%"
+        flex={1}
       >
         <LeftPanel navigation={navigation} />
         <ScrollView>


### PR DESCRIPTION
Content of website doesn't appeared on iphone 11, because the parent element of the screens doesn't have flex={1} property. 